### PR TITLE
feat: add unique id to file and file operation subscription

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bu-sail/s3-viewer",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bu-sail/s3-viewer",
-      "version": "0.0.1-alpha.1",
+      "version": "0.0.1-alpha.2",
       "dependencies": {
         "@cyntler/react-doc-viewer": "^1.13.0",
         "@emotion/react": "^11.11.0",
@@ -31,6 +31,7 @@
         "@storybook/testing-library": "^0.0.14-next.2",
         "@types/react": "^18.0.37",
         "@types/react-dom": "^18.0.11",
+        "@types/uuid": "^9.0.2",
         "@typescript-eslint/eslint-plugin": "^5.59.0",
         "@typescript-eslint/parser": "^5.59.0",
         "@vitejs/plugin-react-swc": "^3.0.0",
@@ -7999,6 +8000,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -22458,6 +22465,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
       "dev": true
     },
     "@types/yargs": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@storybook/testing-library": "^0.0.14-next.2",
     "@types/react": "^18.0.37",
     "@types/react-dom": "^18.0.11",
+    "@types/uuid": "^9.0.2",
     "@typescript-eslint/eslint-plugin": "^5.59.0",
     "@typescript-eslint/parser": "^5.59.0",
     "@vitejs/plugin-react-swc": "^3.0.0",
@@ -60,7 +61,9 @@
   "main": "./dist/s3-viewer.umd.js",
   "module": "./dist/s3-viewer.es.js",
   "types": "./dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "import": "./dist/s3-viewer.es.js",

--- a/src/components/S3Viewer/FileMain.tsx
+++ b/src/components/S3Viewer/FileMain.tsx
@@ -265,7 +265,7 @@ export const FileMain: FC<FileMainProps> = (props) => {
 
   const handleDelete = async () => {
     if (await deleteFileOrFolder(client, bucket, selectedObjects[0])) {
-      trigger('objectDeleted', selectedObjects[0]);
+      trigger(EventType.OBJECT_DELETED, selectedObjects[0]);
     }
     setDeleteDialogOpen(false);
     setSelectedObjects([]);
@@ -294,7 +294,7 @@ export const FileMain: FC<FileMainProps> = (props) => {
         const newKey = selectedObjects[0].$raw.Key.replace(selectedObjects[0].name, newName);
         const newObject = await getFile(client, bucket, { ...selectedObjects[0], $raw: { ...selectedObjects[0].$raw, Key: newKey } });
         if (success) {
-          trigger('objectUpdated', { old: selectedObjects[0], new: newObject });
+          trigger(EventType.OBJECT_UPDATED, { old: selectedObjects[0], new: newObject });
         }
         fetchObjects(ctx.currentPath);
       } catch (err) {
@@ -335,7 +335,7 @@ export const FileMain: FC<FileMainProps> = (props) => {
 
   // initial fetching for files and folders upon opening the page
   useEffect(() => {
-    const eventTypes: EventType[] = ['objectCreated', 'objectUploaded', 'objectDeleted', 'objectUpdated'];
+    const eventTypes: EventType[] = [EventType.OBJECT_UPLOADED, EventType.OBJECT_DELETED, EventType.OBJECT_UPDATED];
     for (const type of eventTypes) {
       subscribe(type, (object: S3Object) => {
         subscribedPlugins.forEach((plugin) => {

--- a/src/components/S3Viewer/FileSearch.tsx
+++ b/src/components/S3Viewer/FileSearch.tsx
@@ -50,9 +50,6 @@ export const FileSearch: FC<FileSearchProps> = (props) => {
       sx={{ width: 300 }}
       getOptionLabel={(option) => `${option.location}/${option.name}`}
       options={options}
-      onFocus={() => {
-        console.log('focused');
-      }}
       onChange={handleChange}
       filterOptions={(x) => x}
       renderInput={(params) => <TextField {...params} size="small" label="Search" variant="outlined" value={input} onChange={handleInputChange} fullWidth />}

--- a/src/components/S3Viewer/ObjectCard.tsx
+++ b/src/components/S3Viewer/ObjectCard.tsx
@@ -116,6 +116,7 @@ export const ObjectCard: FC<ObjectCardProps> = (props) => {
       )}
       {(pluginManager.getPlugins('*') as SideNavPlugin[])?.map((plugin, index) => (
         <MenuItem
+          key={plugin.name}
           onClick={() => {
             handleCloseMore();
             handlePlugin(object, index + 1);

--- a/src/components/S3Viewer/ObjectCard.tsx
+++ b/src/components/S3Viewer/ObjectCard.tsx
@@ -114,18 +114,19 @@ export const ObjectCard: FC<ObjectCardProps> = (props) => {
           <ListItemText primary="Delete" />
         </MenuItem>
       )}
-      {(pluginManager.getPlugins('*') as SideNavPlugin[])?.map((plugin, index) => (
-        <MenuItem
-          key={plugin.name}
-          onClick={() => {
-            handleCloseMore();
-            handlePlugin(object, index + 1);
-          }}
-        >
-          <ListItemIcon> {plugin.icon}</ListItemIcon>
-          <ListItemText>{plugin.name}</ListItemText>
-        </MenuItem>
-      ))}
+      {!object.isFolder &&
+        (pluginManager.getPlugins('*') as SideNavPlugin[])?.map((plugin, index) => (
+          <MenuItem
+            key={plugin.name}
+            onClick={() => {
+              handleCloseMore();
+              handlePlugin(object, index + 1);
+            }}
+          >
+            <ListItemIcon> {plugin.icon}</ListItemIcon>
+            <ListItemText>{plugin.name}</ListItemText>
+          </MenuItem>
+        ))}
       {!object.isFolder && (
         <MenuItem
           onClick={() => {

--- a/src/components/S3Viewer/ObjectRow.tsx
+++ b/src/components/S3Viewer/ObjectRow.tsx
@@ -100,13 +100,17 @@ export const ObjectRow: FC<ObjectRowProps> = (props) => {
           </IconButton>
         </Grid>
       )}
-      {(pluginManager.getPlugins('*') as SideNavPlugin[])?.map((plugin, index) => (
-        <Grid key={plugin.name} item xs={2}>
-          <IconButton onClick={() => handlePlugin(object, index + 1)} sx={displayActions ? {} : { visibility: 'hidden' }}>
-            {plugin.icon}
-          </IconButton>
-        </Grid>
-      ))}
+      {!object.isFolder &&
+        (pluginManager.getPlugins('*') as SideNavPlugin[])?.map(
+          (plugin, index) =>
+            !object.isFolder && (
+              <Grid key={plugin.name} item xs={2}>
+                <IconButton onClick={() => handlePlugin(object, index + 1)} sx={displayActions ? {} : { visibility: 'hidden' }}>
+                  {plugin.icon}
+                </IconButton>
+              </Grid>
+            )
+        )}
       {!object.isFolder && (
         <Grid item xs={2}>
           <IconButton onClick={() => handleDetails(object)} sx={displayActions ? {} : { visibility: 'hidden' }}>

--- a/src/components/S3Viewer/ObjectRow.tsx
+++ b/src/components/S3Viewer/ObjectRow.tsx
@@ -101,7 +101,7 @@ export const ObjectRow: FC<ObjectRowProps> = (props) => {
         </Grid>
       )}
       {(pluginManager.getPlugins('*') as SideNavPlugin[])?.map((plugin, index) => (
-        <Grid item xs={2}>
+        <Grid key={plugin.name} item xs={2}>
           <IconButton onClick={() => handlePlugin(object, index + 1)} sx={displayActions ? {} : { visibility: 'hidden' }}>
             {plugin.icon}
           </IconButton>

--- a/src/components/S3Viewer/S3Viewer.tsx
+++ b/src/components/S3Viewer/S3Viewer.tsx
@@ -4,6 +4,7 @@ import { S3Client } from '@aws-sdk/client-s3';
 import { S3Provider } from '../../contexts/s3-context';
 import { PluginManagerProvider } from '../../contexts/plugins.context';
 import { Plugin } from './../../types/Plugin';
+import { EventBusProvider } from '../../contexts/event-bus.context';
 
 interface S3ViewerProps {
   client: S3Client;
@@ -52,15 +53,17 @@ export const S3Viewer: FC<S3ViewerProps> = (props) => {
 
   return (
     <S3Provider client={props.client} bucket={props.bucket} currentPath={currentPath} setCurrentPath={setCurrentPath} getSignedUrl={props.getSignedUrl}>
-      <PluginManagerProvider plugins={props.plugins || []}>
-        <FileMain
-          client={props.client}
-          bucket={props.bucket}
-          bucketDisplayedName={props.bucketDisplayedName}
-          permissions={permissions}
-          onCurrentPathChange={props.onCurrentPathChange}
-        />
-      </PluginManagerProvider>
+      <EventBusProvider>
+        <PluginManagerProvider plugins={props.plugins || []}>
+          <FileMain
+            client={props.client}
+            bucket={props.bucket}
+            bucketDisplayedName={props.bucketDisplayedName}
+            permissions={permissions}
+            onCurrentPathChange={props.onCurrentPathChange}
+          />
+        </PluginManagerProvider>
+      </EventBusProvider>
     </S3Provider>
   );
 };

--- a/src/contexts/event-bus.context.tsx
+++ b/src/contexts/event-bus.context.tsx
@@ -1,0 +1,35 @@
+import { FC, createContext, useContext, useState } from 'react';
+import { EventBusContextType, EventType } from '../types/Event';
+
+interface EventBusProviderProps {
+  children?: React.ReactNode;
+}
+
+const EventBusContext = createContext<EventBusContextType>({
+  subscribe: () => {},
+  trigger: () => {}
+});
+
+export const EventBusProvider: FC<EventBusProviderProps> = (props) => {
+  const [event, setEvents] = useState<Record<EventType, ((data: any) => void)[]>>({} as any);
+
+  const subscribe = (eventType: EventType, callback: (data: any) => void) => {
+    if (!event[eventType]) {
+      setEvents((prev) => ({ ...prev, [eventType]: [] }));
+    }
+
+    setEvents((prev) => ({ ...prev, [eventType]: [...prev[eventType], callback] }));
+  };
+
+  const trigger = (eventType: EventType, data: any) => {
+    if (event[eventType]) {
+      event[eventType].forEach((callback) => callback(data));
+    }
+  };
+
+  return <EventBusContext.Provider value={{ subscribe, trigger }}>{props.children}</EventBusContext.Provider>;
+};
+
+export const useEventBus = () => {
+  return useContext(EventBusContext);
+};

--- a/src/types/Event.ts
+++ b/src/types/Event.ts
@@ -1,0 +1,6 @@
+export type EventType = 'objectCreated' | 'objectUploaded' | 'objectDeleted' | 'objectUpdated';
+
+export type EventBusContextType = {
+  subscribe: (event: EventType, callback: (data: any) => void) => void;
+  trigger: (event: EventType, data: any) => void;
+};

--- a/src/types/Event.ts
+++ b/src/types/Event.ts
@@ -1,4 +1,8 @@
-export type EventType = 'objectCreated' | 'objectUploaded' | 'objectDeleted' | 'objectUpdated';
+export enum EventType {
+  OBJECT_UPLOADED = 'objectUploaded',
+  OBJECT_UPDATED = 'objectUpdated',
+  OBJECT_DELETED = 'objectDeleted'
+}
 
 export type EventBusContextType = {
   subscribe: (event: EventType, callback: (data: any) => void) => void;

--- a/src/types/S3Object.ts
+++ b/src/types/S3Object.ts
@@ -1,4 +1,5 @@
 export type S3Object = {
+  id: string;
   etag?: string;
   name: string;
   location: string;

--- a/src/types/S3Object.ts
+++ b/src/types/S3Object.ts
@@ -1,5 +1,5 @@
 export type S3Object = {
-  id: string;
+  id?: string;
   etag?: string;
   name: string;
   location: string;

--- a/src/types/S3Object.ts
+++ b/src/types/S3Object.ts
@@ -13,3 +13,7 @@ export type S3Object = {
   fileContent?: string;
   $raw: any;
 };
+
+export type Metadata = {
+  [key: string]: string;
+};

--- a/src/types/SideNavPlugin.ts
+++ b/src/types/SideNavPlugin.ts
@@ -1,6 +1,9 @@
 import { ReactNode } from 'react';
 import { Plugin } from '..';
+import { EventType } from './Event';
 
 export interface SideNavPlugin extends Plugin {
   icon: ReactNode;
+
+  subscriptions: { [key in EventType]?: (data: any) => void };
 }

--- a/src/utils/S3Utils.ts
+++ b/src/utils/S3Utils.ts
@@ -236,6 +236,11 @@ export const getAllFoldersAndFiles = async (client: S3Client, bucketName: string
   return objects;
 };
 
+/**
+ * Fetch all folders and files in the specified bucket that match the specified query.
+ *
+ * @returns an array of S3Object
+ */
 export const searchFoldersAndFiles = async (client: S3Client, bucketName: string, query: string): Promise<S3Object[]> => {
   const objects = await getAllFoldersAndFiles(client, bucketName);
   if (objects.length === 0) {

--- a/src/utils/S3Utils.ts
+++ b/src/utils/S3Utils.ts
@@ -203,12 +203,9 @@ export const getFileByNameAndPath = async (client: S3Client, bucketName: string,
     Key: `${path}${path ? '/' : ''}${name}`
   };
 
-  console.log(params);
-
   try {
     const command = new HeadObjectCommand(params);
     const response = await client.send(command);
-    console.log(response);
 
     return fileToS3Object(client, bucketName, path, { ...response, Key: `${path}${path ? '/' : ''}${name}` });
   } catch (error) {

--- a/src/utils/S3Utils.ts
+++ b/src/utils/S3Utils.ts
@@ -8,12 +8,14 @@ import {
   PutObjectCommand,
   S3Client
 } from '@aws-sdk/client-s3';
+import { v4 as uuid } from 'uuid';
 import { S3Object } from '../types/S3Object';
 
 const fileToS3Object = (path: string, object: any): S3Object => {
   const name = object.Key.endsWith('/') ? object.Key.split('/').slice(-2, -1)[0] : object.Key.split('/').pop();
 
   return {
+    id: object.Metadata?.id ? object.Metadata.id : '',
     etag: object.ETag,
     name,
     location: path.replace(/\/+$/, ''),
@@ -259,6 +261,7 @@ export const uploadFile = async (client: S3Client, bucketName: string, path: str
     Body: file,
     ContentType: file.type,
     Metadata: {
+      id: uuid(),
       'upload-date': new Date().toISOString()
     }
   };


### PR DESCRIPTION
# Description

- Add unique `ID`(uuid) to file and store it in metadata
  - S3 uses `Key` (path/to/file) to uniquely identify file, but it will be changed when file name has been changed or moved
  - If contents are identical, the `Etag` will not be unique
  - When user fetches files, it will check for `ID`. If not present, it will generate a new `ID` and update it on the S3.
- Add file operation subscription
  - Plugin now can subscribe to file operation events (upload, update, delete)

## Checklist

- [x] This PR can be reviewed in under 30 minutes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have assigned reviewers to this PR.
